### PR TITLE
Added crash dump upload section to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/runtime_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/runtime_bug_report.yml
@@ -45,11 +45,18 @@ body:
     attributes:
       label: Logs
       description: Please attach any logs (d3d9.log, .trex\NvRemixBridge.log, gamename_d3d9.log)!
-      placeholder: Upload here!
+      placeholder: Upload logs here!
       value: 
     validations:
       required: false
-
+  - type: textarea
+    attributes:
+      label: Crash dumps
+      description: Please attach any crash dumps (*.dmp, .trex\*.dmp)!
+      placeholder: Upload crash dumps here!
+      value: 
+    validations:
+      required: false
   - type: textarea
     attributes:
       label: Media


### PR DESCRIPTION
Added a section to the runtime bug report template that encourages the bug reporter to upload crash dump files, if available. These files are essential for troubleshooting and can help track down and fix bugs faster.